### PR TITLE
Add CSV Parser

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -16,15 +16,15 @@ jobs:
     - name: Build
       run: swift build -v
     - name: Run tests
-      run: swift test -v --enable-code-coverage
-    - name: Generate lcov report
-      run: xcrun llvm-cov export -format="lcov" .build/debug/cgtcalcPackageTests.xctest/Contents/MacOS/cgtcalcPackageTests -instr-profile .build/debug/codecov/default.profdata > info.lcov
-    - name: Upload code coverage
-      uses: codecov/codecov-action@v2.1.0
-  
+      run: swift test -v # --enable-code-coverage
+    # - name: Generate lcov report
+    #   run: xcrun llvm-cov export -format="lcov" .build/debug/cgtcalcPackageTests.xctest/Contents/MacOS/cgtcalcPackageTests -instr-profile .build/debug/codecov/default.profdata > info.lcov
+    # - name: Upload code coverage
+    #   uses: codecov/codecov-action@v2.1.0
+
   test-linux:
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/Sources/CGTCalcCore/Parser/CSVParser.swift
+++ b/Sources/CGTCalcCore/Parser/CSVParser.swift
@@ -20,6 +20,7 @@ public class  CSVParser: Parser {
   public func calculatorInput(fromData data: String) throws -> CalculatorInput {
     var transactions: [Transaction] = []
     var assetEvents: [AssetEvent] = []
+    // TODO: Replace me with a proper CSV parser that handles quoted fields
     try data
       .split { $0.isNewline }
       .forEach { rowData in
@@ -40,7 +41,7 @@ public class  CSVParser: Parser {
 
   public func transaction(fromData data: Substring) throws -> Transaction? {
     let strippedData = data.trimmingCharacters(in: .whitespaces)
-    let splitData = strippedData.components(separatedBy: ",").filter { $0.count > 0 }
+    let splitData = strippedData.components(separatedBy: ",").map { $0.trimmingCharacters(in: .whitespaces) }.filter { $0.count > 0 }
 
     let kind: Transaction.Kind
     switch splitData[0] {

--- a/Sources/CGTCalcCore/Parser/CSVParser.swift
+++ b/Sources/CGTCalcCore/Parser/CSVParser.swift
@@ -1,0 +1,180 @@
+//
+//  CSVParser.swift
+//  CGTCalcCore
+//
+//  Created by Colin Seymour on 28/03/2023.
+//
+
+import Foundation
+
+public class  CSVParser: Parser {
+  private let dateFormatter: DateFormatter
+
+  public init() {
+    self.dateFormatter = DateFormatter()
+    self.dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+    self.dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+    self.dateFormatter.dateFormat = "dd/MM/yyyy"
+  }
+
+  public func calculatorInput(fromData data: String) throws -> CalculatorInput {
+    var transactions: [Transaction] = []
+    var assetEvents: [AssetEvent] = []
+    try data
+      .split { $0.isNewline }
+      .forEach { rowData in
+        guard rowData.count > 0, rowData.first != "#" else {
+          return
+        }
+
+        if let transaction = try self.transaction(fromData: rowData) {
+          transactions.append(transaction)
+        } else if let assetEvent = try self.assetEvent(fromData: rowData) {
+          assetEvents.append(assetEvent)
+        } else {
+          throw ParserError.InvalidKind(String(rowData))
+        }
+      }
+    return CalculatorInput(transactions: transactions, assetEvents: assetEvents)
+  }
+
+  public func transaction(fromData data: Substring) throws -> Transaction? {
+    let strippedData = data.trimmingCharacters(in: .whitespaces)
+    let splitData = strippedData.components(separatedBy: ",").filter { $0.count > 0 }
+
+    let kind: Transaction.Kind
+    switch splitData[0] {
+    case "BUY":
+      kind = .Buy
+    case "SELL":
+      kind = .Sell
+    default:
+      return nil
+    }
+
+    guard splitData.count == 6 else {
+      throw ParserError.IncorrectNumberOfFields(String(data))
+    }
+
+    guard let date = dateFormatter.date(from: splitData[1]) else {
+      throw ParserError.InvalidDate(String(data))
+    }
+
+    let asset = splitData[2]
+
+    guard let amount = Decimal(string: splitData[3]) else {
+      throw ParserError.InvalidAmount(String(data))
+    }
+
+    guard let price = Decimal(string: splitData[4]) else {
+      throw ParserError.InvalidPrice(String(data))
+    }
+
+    guard let expenses = Decimal(string: splitData[5]) else {
+      throw ParserError.InvalidExpenses(String(data))
+    }
+
+    return Transaction(kind: kind, date: date, asset: asset, amount: amount, price: price, expenses: expenses)
+  }
+
+  public func assetEvent(fromData data: Substring) throws -> AssetEvent? {
+    let splitData = data.components(separatedBy: ",")
+
+    switch splitData[0] {
+    case "DIVIDEND":
+      return try self.parseDividendAssetEvent(fromData: splitData)
+    case "CAPRETURN":
+      return try self.parseCapitalReturnAssetEvent(fromData: splitData)
+    case "SPLIT":
+      return try self.parseSplitAssetEvent(fromData: splitData)
+    case "UNSPLIT":
+      return try self.parseUnsplitAssetEvent(fromData: splitData)
+    default:
+      return nil
+    }
+  }
+
+  private func parseDividendAssetEvent(fromData data: [String]) throws -> AssetEvent {
+    guard data.count >= 5 else {
+      throw ParserError.IncorrectNumberOfFields(data.joined(separator: " "))
+    }
+
+    guard let date = dateFormatter.date(from: data[1]) else {
+      throw ParserError.InvalidDate(data.joined(separator: " "))
+    }
+
+    let asset = data[2]
+
+    guard let amount = Decimal(string: data[3]) else {
+      throw ParserError.InvalidValue(data.joined(separator: " "))
+    }
+
+    guard let value = Decimal(string: data[4]) else {
+      throw ParserError.InvalidValue(data.joined(separator: " "))
+    }
+
+    let kind = AssetEvent.Kind.Dividend(amount, value)
+    return AssetEvent(kind: kind, date: date, asset: asset)
+  }
+
+  private func parseCapitalReturnAssetEvent(fromData data: [String]) throws -> AssetEvent {
+    guard data.count >= 5 else {
+      throw ParserError.IncorrectNumberOfFields(data.joined(separator: " "))
+    }
+
+    guard let date = dateFormatter.date(from: data[1]) else {
+      throw ParserError.InvalidDate(data.joined(separator: " "))
+    }
+
+    let asset = data[2]
+
+    guard let amount = Decimal(string: data[3]) else {
+      throw ParserError.InvalidValue(data.joined(separator: " "))
+    }
+
+    guard let value = Decimal(string: data[4]) else {
+      throw ParserError.InvalidValue(data.joined(separator: " "))
+    }
+
+    let kind = AssetEvent.Kind.CapitalReturn(amount, value)
+    return AssetEvent(kind: kind, date: date, asset: asset)
+  }
+
+  private func parseSplitAssetEvent(fromData data: [String]) throws -> AssetEvent {
+    guard data.count >= 4 else {
+      throw ParserError.IncorrectNumberOfFields(data.joined(separator: " "))
+    }
+
+    guard let date = dateFormatter.date(from: data[1]) else {
+      throw ParserError.InvalidDate(data.joined(separator: " "))
+    }
+
+    let asset = data[2]
+
+    guard let multiplier = Decimal(string: data[3]) else {
+      throw ParserError.InvalidValue(data.joined(separator: " "))
+    }
+
+    let kind = AssetEvent.Kind.Split(multiplier)
+    return AssetEvent(kind: kind, date: date, asset: asset)
+  }
+
+  private func parseUnsplitAssetEvent(fromData data: [String]) throws -> AssetEvent {
+    guard data.count >= 4 else {
+      throw ParserError.IncorrectNumberOfFields(data.joined(separator: " "))
+    }
+
+    guard let date = dateFormatter.date(from: data[1]) else {
+      throw ParserError.InvalidDate(data.joined(separator: " "))
+    }
+
+    let asset = data[2]
+
+    guard let multiplier = Decimal(string: data[3]) else {
+      throw ParserError.InvalidValue(data.joined(separator: " "))
+    }
+
+    let kind = AssetEvent.Kind.Unsplit(multiplier)
+    return AssetEvent(kind: kind, date: date, asset: asset)
+  }
+}

--- a/Sources/CGTCalcCore/Parser/DefaultParser.swift
+++ b/Sources/CGTCalcCore/Parser/DefaultParser.swift
@@ -3,31 +3,12 @@
 //  CGTCalcCore
 //
 //  Created by Matt Galloway on 09/06/2020.
+//  Modified by Colin Seymour on 28/03/2023.
 //
 
 import Foundation
 
-enum ParserError: Error {
-  case IncorrectNumberOfFields(String)
-  case InvalidKind(String)
-  case InvalidDate(String)
-  case InvalidAmount(String)
-  case InvalidPrice(String)
-  case InvalidExpenses(String)
-  case InvalidValue(String)
-}
-
-public class CalculatorInput {
-  public let transactions: [Transaction]
-  public let assetEvents: [AssetEvent]
-
-  public init(transactions: [Transaction], assetEvents: [AssetEvent]) {
-    self.transactions = transactions
-    self.assetEvents = assetEvents
-  }
-}
-
-public class DefaultParser {
+public class DefaultParser: Parser {
   private let dateFormatter: DateFormatter
 
   public init() {

--- a/Sources/CGTCalcCore/Parser/Parser.swift
+++ b/Sources/CGTCalcCore/Parser/Parser.swift
@@ -1,0 +1,33 @@
+//
+//  Parser.swift
+//  CGTCalcCore
+//
+//  Created by Colin Seymour on 28/03/2023.
+//
+
+import Foundation
+
+public enum ParserError: Error {
+  case IncorrectNumberOfFields(String)
+  case InvalidKind(String)
+  case InvalidDate(String)
+  case InvalidAmount(String)
+  case InvalidPrice(String)
+  case InvalidExpenses(String)
+  case InvalidValue(String)
+}
+
+public class CalculatorInput {
+  public let transactions: [Transaction]
+  public let assetEvents: [AssetEvent]
+
+  public init(transactions: [Transaction], assetEvents: [AssetEvent]) {
+    self.transactions = transactions
+    self.assetEvents = assetEvents
+  }
+}
+
+public protocol Parser {
+  func calculatorInput(fromData data: String) throws -> CalculatorInput
+}
+

--- a/Sources/cgtcalc/main.swift
+++ b/Sources/cgtcalc/main.swift
@@ -31,7 +31,16 @@ struct CGTCalc: ParsableCommand {
 
     do {
       let data = try String(contentsOfFile: filename)
-      let parser = DefaultParser()
+      // If first line contains a comma, assume CSV
+      let firstLine = data.split(separator: "\n").first ?? ""
+      let parser: Parser
+      if firstLine.contains(",") {
+        logger.info("Detected CSV input")
+        parser = CSVParser()
+      } else {
+        logger.info("Detected default input")
+        parser = DefaultParser()
+      }
       let input = try parser.calculatorInput(fromData: data)
 
       let calculator = try Calculator(input: input, logger: logger)

--- a/Sources/cgtcalc/main.swift
+++ b/Sources/cgtcalc/main.swift
@@ -3,6 +3,7 @@
 //  cgtcalc
 //
 //  Created by Matt Galloway on 06/06/2020.
+//  Modified by Colin Seymour on 28/03/2023.
 //
 
 import ArgumentParser

--- a/Tests/CGTCalcCoreTests/CSVParserTests.swift
+++ b/Tests/CGTCalcCoreTests/CSVParserTests.swift
@@ -1,0 +1,278 @@
+//
+//  CSVParserTests.swift
+//  CGTCalcCoreTests
+//
+//  Created by Colin Seymour on 28/03/2023.
+//
+
+@testable import CGTCalcCore
+import XCTest
+
+class  CSVParserTests: XCTestCase {
+  func testParseBuyTransactionSuccess() throws {
+    let sut = CSVParser()
+    let data = "BUY,15/08/2020,Foo,12.345,1.2345,12.5"
+    let transaction = try sut.transaction(fromData: Substring(data))
+    XCTAssertNotNil(transaction)
+    XCTAssertEqual(transaction!.kind, .Buy)
+    XCTAssertEqual(transaction!.date, Date(timeIntervalSince1970: 1597449600))
+    XCTAssertEqual(transaction!.asset, "Foo")
+    XCTAssertEqual(transaction!.amount, Decimal(12.345))
+    XCTAssertEqual(transaction!.price, Decimal(1.2345))
+    XCTAssertEqual(transaction!.expenses, Decimal(12.5))
+  }
+
+  func testParseSellTransactionSuccess() throws {
+    let sut =  CSVParser()
+    let data = "SELL,15/08/2020,Foo,12.345,1.2345,12.5"
+    let transaction = try sut.transaction(fromData: Substring(data))
+    XCTAssertNotNil(transaction)
+    XCTAssertEqual(transaction!.kind, .Sell)
+    XCTAssertEqual(transaction!.date, Date(timeIntervalSince1970: 1597449600))
+    XCTAssertEqual(transaction!.asset, "Foo")
+    XCTAssertEqual(transaction!.amount, Decimal(12.345))
+    XCTAssertEqual(transaction!.price, Decimal(1.2345))
+    XCTAssertEqual(transaction!.expenses, Decimal(12.5))
+  }
+
+  func testParseStripsTrailingWhitespace() throws {
+    let sut =  CSVParser()
+    let data = "BUY,15/08/2020,Foo,12.345,1.2345,12.5,   \t\t   "
+    let transaction = try sut.transaction(fromData: Substring(data))
+    XCTAssertNotNil(transaction)
+    XCTAssertEqual(transaction!.kind, .Buy)
+    XCTAssertEqual(transaction!.date, Date(timeIntervalSince1970: 1597449600))
+    XCTAssertEqual(transaction!.asset, "Foo")
+    XCTAssertEqual(transaction!.amount, Decimal(12.345))
+    XCTAssertEqual(transaction!.price, Decimal(1.2345))
+    XCTAssertEqual(transaction!.expenses, Decimal(12.5))
+  }
+
+  func testParseAllowsMultipleWhitespace() throws {
+    let sut =  CSVParser()
+    let data = "BUY,     15/08/2020  ,  Foo ,  12.345,  1.2345,12.5"
+    let transaction = try sut.transaction(fromData: Substring(data))
+    XCTAssertNotNil(transaction)
+    XCTAssertEqual(transaction!.kind, .Buy)
+    XCTAssertEqual(transaction!.date, Date(timeIntervalSince1970: 1597449600))
+    XCTAssertEqual(transaction!.asset, "Foo")
+    XCTAssertEqual(transaction!.amount, Decimal(12.345))
+    XCTAssertEqual(transaction!.price, Decimal(1.2345))
+    XCTAssertEqual(transaction!.expenses, Decimal(12.5))
+  }
+
+  func testParseCapitalReturnEventSuccess() throws {
+    let sut =  CSVParser()
+    let data = "CAPRETURN,15/08/2020,Foo,1.234,100"
+    let transaction = try sut.assetEvent(fromData: Substring(data))
+    XCTAssertNotNil(transaction)
+    XCTAssertEqual(transaction!.kind, .CapitalReturn(Decimal(1.234), Decimal(100)))
+    XCTAssertEqual(transaction!.date, Date(timeIntervalSince1970: 1597449600))
+    XCTAssertEqual(transaction!.asset, "Foo")
+  }
+
+  func testParseCapitalReturnEventTooManyFieldsSuccess() throws {
+    let sut =  CSVParser()
+    let data = "CAPRETURN,15/08/2020,Foo,1.234,100,abc"
+    let transaction = try sut.assetEvent(fromData: Substring(data))
+    XCTAssertNotNil(transaction)
+    XCTAssertEqual(transaction!.kind, .CapitalReturn(Decimal(1.234), Decimal(100)))
+    XCTAssertEqual(transaction!.date, Date(timeIntervalSince1970: 1597449600))
+    XCTAssertEqual(transaction!.asset, "Foo")
+  }
+
+  func testParseDividendEventSuccess() throws {
+    let sut =  CSVParser()
+    let data = "DIVIDEND,15/08/2020,Foo,1.234,100"
+    let transaction = try sut.assetEvent(fromData: Substring(data))
+    XCTAssertNotNil(transaction)
+    XCTAssertEqual(transaction!.kind, .Dividend(Decimal(1.234), Decimal(100)))
+    XCTAssertEqual(transaction!.date, Date(timeIntervalSince1970: 1597449600))
+    XCTAssertEqual(transaction!.asset, "Foo")
+  }
+
+  func testParseDividendAssetEventTooManyFieldsSuccess() throws {
+    let sut =  CSVParser()
+    let data = "DIVIDEND,15/08/2020,Foo,1.234,100,100"
+    let transaction = try sut.assetEvent(fromData: Substring(data))
+    XCTAssertNotNil(transaction)
+    XCTAssertEqual(transaction!.kind, .Dividend(Decimal(1.234), Decimal(100)))
+    XCTAssertEqual(transaction!.date, Date(timeIntervalSince1970: 1597449600))
+    XCTAssertEqual(transaction!.asset, "Foo")
+  }
+
+  func testParseSplitEventSuccess() throws {
+    let sut =  CSVParser()
+    let data = "SPLIT,15/08/2020,Foo,10"
+    let transaction = try sut.assetEvent(fromData: Substring(data))
+    XCTAssertNotNil(transaction)
+    XCTAssertEqual(transaction!.kind, .Split(Decimal(10)))
+    XCTAssertEqual(transaction!.date, Date(timeIntervalSince1970: 1597449600))
+    XCTAssertEqual(transaction!.asset, "Foo")
+  }
+
+  func testParseSplitEventTooManyFieldsSuccess() throws {
+    let sut =  CSVParser()
+    let data = "SPLIT,15/08/2020,Foo,10,abc"
+    let transaction = try sut.assetEvent(fromData: Substring(data))
+    XCTAssertNotNil(transaction)
+    XCTAssertEqual(transaction!.kind, .Split(Decimal(10)))
+    XCTAssertEqual(transaction!.date, Date(timeIntervalSince1970: 1597449600))
+    XCTAssertEqual(transaction!.asset, "Foo")
+  }
+
+  func testParseUnsplitEventSuccess() throws {
+    let sut =  CSVParser()
+    let data = "UNSPLIT,15/08/2020,Foo,10"
+    let transaction = try sut.assetEvent(fromData: Substring(data))
+    XCTAssertNotNil(transaction)
+    XCTAssertEqual(transaction!.kind, .Unsplit(Decimal(10)))
+    XCTAssertEqual(transaction!.date, Date(timeIntervalSince1970: 1597449600))
+    XCTAssertEqual(transaction!.asset, "Foo")
+  }
+
+  func testParseUnsplitEventTooManyFieldsSuccess() throws {
+    let sut =  CSVParser()
+    let data = "UNSPLIT,15/08/2020,Foo,10,abc"
+    let transaction = try sut.assetEvent(fromData: Substring(data))
+    XCTAssertNotNil(transaction)
+    XCTAssertEqual(transaction!.kind, .Unsplit(Decimal(10)))
+    XCTAssertEqual(transaction!.date, Date(timeIntervalSince1970: 1597449600))
+    XCTAssertEqual(transaction!.asset, "Foo")
+  }
+
+  func testParseCommentSuccess() throws {
+    let sut =  CSVParser()
+    let data = "# THIS IS A, COMMENT"
+    let transaction = try sut.transaction(fromData: Substring(data))
+    XCTAssertNil(transaction)
+  }
+
+  func testParseTransactionIncorrectKindFails() throws {
+    let sut =  CSVParser()
+    let data = "FOOBAR,08/15/2020,Foo,12.345,1.2345,12.5"
+    let transaction = try sut.transaction(fromData: Substring(data))
+    XCTAssertNil(transaction)
+  }
+
+  func testParseAssetEventIncorrectKindFails() throws {
+    let sut =  CSVParser()
+    let data = "FOOBAR,08/15/2020,Foo,12.345,1.2345,12.5"
+    let transaction = try sut.assetEvent(fromData: Substring(data))
+    XCTAssertNil(transaction)
+  }
+
+  func testParseTransactionIncorrectDateFormatFails() throws {
+    let sut =  CSVParser()
+    let data = "BUY,abc,Foo,12.345,1.2345,12.5"
+    XCTAssertThrowsError(try sut.transaction(fromData: Substring(data)))
+  }
+
+  func testParseTransactionIncorrectNumberOfFieldsFails() throws {
+    let sut =  CSVParser()
+    let data = "BUY,15/08/2020,Foo,12.345,1.2345"
+    XCTAssertThrowsError(try sut.transaction(fromData: Substring(data)))
+  }
+
+  func testParseTransactionIncorrectAmountFormatFails() throws {
+    let sut =  CSVParser()
+    let data = "BUY,15/08/2020,Foo,abc,1.2345,12.5"
+    XCTAssertThrowsError(try sut.transaction(fromData: Substring(data)))
+  }
+
+  func testParseTransactionIncorrectPriceFormatFails() throws {
+    let sut =  CSVParser()
+    let data = "BUY,15/08/2020,Foo,12.345,def,12.5"
+    XCTAssertThrowsError(try sut.transaction(fromData: Substring(data)))
+  }
+
+  func testParseTransactionIncorrectExpensesFormatFails() throws {
+    let sut =  CSVParser()
+    let data = "BUY,15/08/2020,Foo,12.345,1.2345,abc"
+    XCTAssertThrowsError(try sut.transaction(fromData: Substring(data)))
+  }
+
+  func testParseDividendAssetEventIncorrectDateFormatFails() throws {
+    let sut =  CSVParser()
+    let data = "DIVIDEND,abc,Foo,1.234,100"
+    XCTAssertThrowsError(try sut.assetEvent(fromData: Substring(data)))
+  }
+
+  func testParseDividendAssetEventTooFewFieldsFails() throws {
+    let sut =  CSVParser()
+    let data = "DIVIDEND,15/08/2020,Foo,1.234"
+    XCTAssertThrowsError(try sut.assetEvent(fromData: Substring(data)))
+  }
+
+  func testParseDividendAssetEventIncorrectAmountFormatFails() throws {
+    let sut =  CSVParser()
+    let data = "DIVIDEND,15/08/2020,Foo,abc,100"
+    XCTAssertThrowsError(try sut.assetEvent(fromData: Substring(data)))
+  }
+
+  func testParseDividendAssetEventIncorrectValueFormatFails() throws {
+    let sut =  CSVParser()
+    let data = "DIVIDEND,15/08/2020,Foo,1.234,abc"
+    XCTAssertThrowsError(try sut.assetEvent(fromData: Substring(data)))
+  }
+
+  func testParseCapitalReturnAssetEventIncorrectDateFormatFails() throws {
+    let sut =  CSVParser()
+    let data = "CAPRETURN,abc,Foo,1.234,100"
+    XCTAssertThrowsError(try sut.assetEvent(fromData: Substring(data)))
+  }
+
+  func testParseCapitalReturnEventTooFewFieldsFails() throws {
+    let sut =  CSVParser()
+    let data = "CAPRETURN,15/08/2020,Foo,1.234"
+    XCTAssertThrowsError(try sut.assetEvent(fromData: Substring(data)))
+  }
+
+  func testParseCapitalReturnEventIncorrectAmountFormatFails() throws {
+    let sut =  CSVParser()
+    let data = "CAPRETURN,15/08/2020,Foo,abc,100"
+    XCTAssertThrowsError(try sut.assetEvent(fromData: Substring(data)))
+  }
+
+  func testParseCapitalReturnEventIncorrectValueFormatFails() throws {
+    let sut =  CSVParser()
+    let data = "CAPRETURN,15/08/2020,Foo,1.234,abc"
+    XCTAssertThrowsError(try sut.assetEvent(fromData: Substring(data)))
+  }
+
+  func testParseSplitAssetEventIncorrectDateFormatFails() throws {
+    let sut =  CSVParser()
+    let data = "SPLIT,abc,Foo,10"
+    XCTAssertThrowsError(try sut.assetEvent(fromData: Substring(data)))
+  }
+
+  func testParseSplitEventTooFewFieldsFails() throws {
+    let sut =  CSVParser()
+    let data = "SPLIT,15/08/2020,Foo"
+    XCTAssertThrowsError(try sut.assetEvent(fromData: Substring(data)))
+  }
+
+  func testParseSplitEventIncorrectAmountFormatFails() throws {
+    let sut =  CSVParser()
+    let data = "SPLIT,15/08/2020,Foo,abc"
+    XCTAssertThrowsError(try sut.assetEvent(fromData: Substring(data)))
+  }
+
+  func testParseUnsplitAssetEventIncorrectDateFormatFails() throws {
+    let sut =  CSVParser()
+    let data = "UNSPLIT,abc,Foo,10"
+    XCTAssertThrowsError(try sut.assetEvent(fromData: Substring(data)))
+  }
+
+  func testParseUnsplitEventTooFewFieldsFails() throws {
+    let sut =  CSVParser()
+    let data = "UNSPLIT,15/08/2020,Foo"
+    XCTAssertThrowsError(try sut.assetEvent(fromData: Substring(data)))
+  }
+
+  func testParseUnsplitEventIncorrectAmountFormatFails() throws {
+    let sut =  CSVParser()
+    let data = "UNSPLIT,15/08/2020,Foo,abc"
+    XCTAssertThrowsError(try sut.assetEvent(fromData: Substring(data)))
+  }
+}


### PR DESCRIPTION
I store all my transactions in Google Sheets and then export to a CSV file for processing by cgtcalc. Adding a CSV parser removes the `s/,/ /g` step from my normal process.

This is a crude CSV parser which is just a tweak of the `DefaultParser` and doesn't handle quoted fields. I'll switch to using a real CSV parser if and when I start producing CSV files with quoted fields.

The CSV parser is also automatically used if the first line of the input file contains a comma.

I also don't care about code coverage so I've commented that out.