### PR TITLE
Add markdown presenter with other improvements

### DIFF
--- a/Sources/CGTCalcCore/Parser/CSVParser.swift
+++ b/Sources/CGTCalcCore/Parser/CSVParser.swift
@@ -24,7 +24,7 @@ public class  CSVParser: Parser {
     try data
       .split { $0.isNewline }
       .forEach { rowData in
-        guard rowData.count > 0, rowData.first != "#" else {
+        guard rowData.count > 0, (rowData.first != "#" && rowData.first != ",") else {
           return
         }
 

--- a/Sources/CGTCalcCore/Presenter/MarkdownPresenter.swift
+++ b/Sources/CGTCalcCore/Presenter/MarkdownPresenter.swift
@@ -1,0 +1,234 @@
+//
+//  MarkdownPresenter.swift
+//  cgtcalc
+//
+//  Created by Colin Seymour on 06/11/2023.
+//
+
+import Foundation
+
+public class MarkdownPresenter: Presenter {
+  private let result: CalculatorResult
+  private let dateFormatter: DateFormatter
+
+  public required init(result: CalculatorResult) {
+    self.result = result
+    let dateFormatter = DateFormatter()
+    dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+    dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+    dateFormatter.dateFormat = "dd/MM/yyyy"
+    self.dateFormatter = dateFormatter
+  }
+
+  public func process() throws -> PresenterResult {
+    var output = ""
+    output += "# SUMMARY\n\n"
+    output += self.summaryTable()
+
+    output += "\n"
+
+    output += "## TAX YEAR DETAILS\n\n"
+    output += self.detailsOutput()
+
+    output += "## TRANSACTIONS\n\n"
+    output += self.transactionsTable()
+
+    output += "\n---\n\n"
+
+    output += "## ASSET EVENTS\n\n"
+    output += self.assetEventsTable()
+
+    return .string(output)
+  }
+
+  private func formattedCurrency(_ amount: Decimal) -> String {
+    return "£\(amount.rounded(to: 2).string)"
+  }
+
+  private func summaryTable() -> String {
+    let rows = self.result.taxYearSummaries
+      .reduce(into: [[String]]()) { output, summary in
+        let row = [
+          summary.taxYear.string,
+          String(summary.disposalResults.count),
+          self.formattedCurrency(summary.proceeds),
+          self.formattedCurrency(summary.proceeds - summary.gain),
+          self.formattedCurrency(summary.gain),
+          self.formattedCurrency(summary.exemption),
+          self.formattedCurrency(summary.carryForwardLoss),
+          self.formattedCurrency(summary.taxableGain),
+          self.formattedCurrency(summary.basicRateTax),
+          self.formattedCurrency(summary.higherRateTax)
+        ]
+        output.append(row)
+      }
+
+    let headerRow = [
+      "Tax year",
+      "Disposals",
+      "Proceeds",
+      "Allowable costs",
+      "Gain",
+      "Exemption",
+      "Loss carry",
+      "Taxable gain",
+      "Tax (basic)",
+      "Tax (higher)"
+    ]
+    let initialMaxWidths = headerRow.map { $0.count }
+    let maxWidths = rows.reduce(into: initialMaxWidths) { result, row in
+      for i in 0 ..< result.count {
+        result[i] = max(result[i], row[i].count)
+      }
+    }
+
+    let builder = { (input: [String]) -> String in
+      var out: [String] = []
+      for (i, column) in input.enumerated() {
+        out.append("| " + column.padding(toLength: maxWidths[i], withPad: " ", startingAt: 0))
+      }
+      return out.joined(separator: " ")
+    }
+
+    let underlineBuilder = { (input: [String]) -> String in
+      var out: [String] = []
+      for (i, _) in input.enumerated() {
+        out.append("| " + String(repeating: "-", count: maxWidths[i]))
+      }
+      return out.joined(separator: " ")
+    }
+
+    let header = builder(headerRow)
+    var output = header + " |\n"
+    output += underlineBuilder(headerRow) + " |\n"
+    for row in rows {
+      output += builder(row) + " |\n"
+    }
+    return output
+  }
+
+  private func detailsOutput() -> String {
+    return self.result.taxYearSummaries
+      .reduce(into: "") { output, summary in
+        output += "### TAX YEAR \(summary.taxYear)\n\n"
+
+        output += "Disposals: \(summary.disposalResults.count)\n"
+        output += "Proceeds: \(self.formattedCurrency(summary.proceeds))\n"
+        output += "Allowable costs: \(self.formattedCurrency(summary.proceeds - summary.gain))\n"
+
+        let gains = summary.disposalResults.filter({$0.gain >= 0})
+        output += "\(gains.count) gains with total of \(self.formattedCurrency(gains.reduce(Decimal.zero) {$0 + $1.gain}))\n"
+
+        let losses = summary.disposalResults.filter({$0.gain < 0})
+        output += "\(losses.count) losses with total of \(self.formattedCurrency(losses.reduce(Decimal.zero) {$0 - $1.gain}))\n"
+
+        output += "\n"
+
+        var count = 1
+        summary.disposalResults
+          .forEach { disposalResult in
+            output += "\(count). SOLD \(disposalResult.disposal.amount)"
+            output += " of \(disposalResult.disposal.asset)"
+            output += " on \(self.dateFormatter.string(from: disposalResult.disposal.date))"
+            output += " for "
+            output += disposalResult.gain.isSignMinus ? "LOSS" : "GAIN"
+            output +=
+              " of \(self.formattedCurrency(disposalResult.gain * (disposalResult.gain.isSignMinus ? -1 : 1)))\n"
+            output += "   Matches with:\n"
+            disposalResult.disposalMatches.forEach { disposalMatch in
+              output += "     - \(MarkdownPresenter.disposalMatchDetails(disposalMatch, dateFormatter: self.dateFormatter))\n"
+            }
+            output += "   Calculation: \(MarkdownPresenter.disposalResultCalculationString(disposalResult))\n\n"
+            count += 1
+          }
+        output += "---\n\n"
+      }
+  }
+
+  private func transactionsTable() -> String {
+    guard self.result.input.transactions.count > 0 else {
+      return "NONE"
+    }
+
+    return self.result.input.transactions.reduce(into: "") { result, transaction in
+      result += "\(dateFormatter.string(from: transaction.date)) "
+      switch transaction.kind {
+      case .Buy:
+        result += "BOUGHT "
+      case .Sell:
+        result += "SOLD "
+      }
+      result +=
+        "\(transaction.amount) of \(transaction.asset) at £\(transaction.price) with £\(transaction.expenses) expenses\n"
+    }
+  }
+
+  private func assetEventsTable() -> String {
+    guard self.result.input.assetEvents.count > 0 else {
+      return "NONE"
+    }
+
+    return self.result.input.assetEvents.reduce(into: "") { result, assetEvent in
+      result += "\(dateFormatter.string(from: assetEvent.date)) \(assetEvent.asset) "
+      switch assetEvent.kind {
+      case .CapitalReturn(let amount, let value):
+        result += "CAPITAL RETURN on \(amount) for \(self.formattedCurrency(value))"
+      case .Dividend(let amount, let value):
+        result += "DIVIDEND on \(amount) for \(self.formattedCurrency(value))"
+      case .Split(let multiplier):
+        result += "SPLIT by \(multiplier)"
+      case .Unsplit(let multiplier):
+        result += "UNSPLIT by \(multiplier)"
+      }
+      result += "\n"
+    }
+  }
+}
+
+extension MarkdownPresenter {
+  private static func disposalMatchDetails(_ disposalMatch: DisposalMatch, dateFormatter: DateFormatter) -> String {
+    switch disposalMatch.kind {
+    case .SameDay(let acquisition):
+      var output =
+        "SAME DAY: \(acquisition.amount) bought on \(dateFormatter.string(from: acquisition.date)) at £\(acquisition.price)"
+      if !acquisition.offset.isZero {
+        output += " with offset of £\(acquisition.offset)"
+      }
+      return output
+    case .BedAndBreakfast(let acquisition):
+      var output =
+        "BED & BREAKFAST: \(acquisition.amount) bought on \(dateFormatter.string(from: acquisition.date)) at £\(acquisition.price)"
+      if !acquisition.offset.isZero {
+        output += " with offset of £\(acquisition.offset)"
+      }
+      if disposalMatch.restructureMultiplier != Decimal(1) {
+        output += " with restructure multiplier \(disposalMatch.restructureMultiplier)"
+      }
+      return output
+    case .Section104(let amountAtDisposal, let costBasis):
+      return "SECTION 104: \(amountAtDisposal) at cost basis of £\(costBasis.rounded(to: 5).string)"
+    }
+  }
+
+  private static func disposalResultCalculationString(_ disposalResult: CalculatorResult.DisposalResult) -> String {
+    var output =
+      "(\(disposalResult.disposal.amount) * \(disposalResult.disposal.price) - \(disposalResult.disposal.expenses)) - ( "
+    var disposalMatchesStrings: [String] = []
+    for disposalMatch in disposalResult.disposalMatches {
+      switch disposalMatch.kind {
+      case .SameDay(let acquisition), .BedAndBreakfast(let acquisition):
+        var output = "(\(acquisition.amount) * \(acquisition.price) + \(acquisition.expenses)"
+        if !acquisition.offset.isZero {
+          output += " + \(acquisition.offset)"
+        }
+        output += ")"
+        disposalMatchesStrings.append(output)
+      case .Section104(_, let costBasis):
+        disposalMatchesStrings.append("(\(disposalMatch.disposal.amount) * \(costBasis.rounded(to: 5).string))")
+      }
+    }
+    output += disposalMatchesStrings.joined(separator: " + ")
+    output += " ) = \(disposalResult.gain)"
+    return output
+  }
+}

--- a/Sources/cgtcalc/main.swift
+++ b/Sources/cgtcalc/main.swift
@@ -47,7 +47,17 @@ struct CGTCalc: ParsableCommand {
       let calculator = try Calculator(input: input, logger: logger)
       let result = try calculator.process()
 
-      let presenter = TextPresenter(result: result)
+      let presenter: Presenter
+      // If the filename ends in .md, assume markdown
+      let outputFile = self.outputFile ?? "-"
+      if outputFile.hasSuffix(".md") {
+        logger.info("Detected markdown output")
+        presenter = MarkdownPresenter(result: result)
+      } else {
+        logger.info("Detected default text output")
+        presenter = TextPresenter(result: result)
+      }
+
       let output = try presenter.process()
 
       if let outputFile = self.outputFile, outputFile != "-" {


### PR DESCRIPTION
I use Markdown for a lot of things and would like to keep this report in Obsidian in markdown format. This PR adds a markdown presenter output that will produce markdown if the output filename ends in `.md`.

I've also taken the time to add "Disposals" and "Allowable costs" columns to the summary table.

I've also added "Disposals", "Proceeds", and "Allowable costs" lines to each annual summary to make filling in my self-assessment easier.

All in the basic output looks like this now:

```markdown
# SUMMARY

| Tax year  | Disposals | Proceeds | Allowable costs | Gain   | Exemption | Loss carry | Taxable gain | Tax (basic) | Tax (higher) |
| --------- | --------- | -------- | --------------- | ------ | --------- | ---------- | ------------ | ----------- | ------------ |
| 2018/2019 | 2         | £21028   | £21104          | £-76   | £11700    | £76        | £0           | £0          | £0           |

## TAX YEAR DETAILS

### TAX YEAR 2018/2019

Disposals: 2
Proceeds: £21028
Allowable costs: £21104
0 gains with total of £0
2 losses with total of £76

1. SOLD 130 of NASDAQ:FOOBAR on 17/01/2019 for LOSS of £53
   Matches with:
     - BED & BREAKFAST: 126 bought on 01/02/2019 at £79.58
     - SECTION 104: 130 at cost basis of £79.62
   Calculation: (130 * 79.69 - 66.31) - ( (126 * 79.58 + 0) + (4 * 79.62) ) = -53

2. SOLD 126 of NASDAQ:FOOBAR on 26/02/2019 for LOSS of £23
   Matches with:
     - BED & BREAKFAST: 126 bought on 01/03/2019 at £84.3
   Calculation: (126 * 84.67 - 69.55) - ( (126 * 84.3 + 0) ) = -23

```

... which plays nicely as markdown:


# SUMMARY

| Tax year  | Disposals | Proceeds | Allowable costs | Gain   | Exemption | Loss carry | Taxable gain | Tax (basic) | Tax (higher) |
| --------- | --------- | -------- | --------------- | ------ | --------- | ---------- | ------------ | ----------- | ------------ |
| 2018/2019 | 2         | £21028   | £21104          | £-76   | £11700    | £76        | £0           | £0          | £0           |

## TAX YEAR DETAILS

### TAX YEAR 2018/2019

Disposals: 2
Proceeds: £21028
Allowable costs: £21104
0 gains with total of £0
2 losses with total of £76

1. SOLD 130 of NASDAQ:FOOBAR on 17/01/2019 for LOSS of £53
   Matches with:
     - BED & BREAKFAST: 126 bought on 01/02/2019 at £79.58
     - SECTION 104: 130 at cost basis of £79.62
   Calculation: (130 * 79.69 - 66.31) - ( (126 * 79.58 + 0) + (4 * 79.62) ) = -53

2. SOLD 126 of NASDAQ:FOOBAR on 26/02/2019 for LOSS of £23
   Matches with:
     - BED & BREAKFAST: 126 bought on 01/03/2019 at £84.3
   Calculation: (126 * 84.67 - 69.55) - ( (126 * 84.3 + 0) ) = -23


I've also squeezed in better handling for empty rows in CSV files which contain only commas.